### PR TITLE
Support Absinthe.Resolution errors in build_payload/2

### DIFF
--- a/lib/kronky/payload.ex
+++ b/lib/kronky/payload.ex
@@ -191,8 +191,25 @@ defmodule Kronky.Payload do
   in your resolver instead. See `convert_to_payload/1`, `success_payload/1` and `error_payload/1` for examples.
 
   """
-  def build_payload(%{value: value} = resolution, _config) do
+  def build_payload(%{value: value, errors: []} = resolution, _config) do
     result = convert_to_payload(value)
+    Absinthe.Resolution.put_result(resolution, {:ok, result})
+  end
+
+  @doc """
+  Convert resolution errors to a mutation payload
+
+  The build payload middleware will accept lists of `Kronky.ValidationMessage` or string errors.
+
+  Valid formats are:
+  ```
+  [%ValidationMessage{},%ValidationMessage{}]
+  "This is an error"
+  ["This is an error", "This is another error"]
+  ```
+  """
+  def build_payload(%{errors: errors} = resolution, _config) do
+    result = convert_to_payload({:error, errors})
     Absinthe.Resolution.put_result(resolution, {:ok, result})
   end
 


### PR DESCRIPTION
Support Absinthe.Resolution errors from Middleware in build_payload/2 like in [Absinthe documentation](https://hexdocs.pm/absinthe/Absinthe.Middleware.html):

```
defmodule MyApp.Web.Authentication do
  @behaviour Absinthe.Middleware

  def call(resolution, _config) do
    case resolution.context do
      %{current_user: _} ->
        resolution
      _ ->
        resolution
        |> Absinthe.Resolution.put_result({:error, "unauthenticated"})
    end
  end
end
```

This way, we won't have to return an `ok` tuple in custom Middleware and it will be compatible with third party Middleware.