### PR TITLE
Fix encoding of validation message options

### DIFF
--- a/lib/kronky/payload.ex
+++ b/lib/kronky/payload.ex
@@ -330,8 +330,15 @@ defmodule Kronky.Payload do
     field |> to_string() |> Absinthe.Utils.camelize(lower: true)
   end
 
+  defp convert_options(%ValidationMessage{} = message) do
+    options = message.options |> Enum.map(fn {key, value} -> %{key: to_string(key), value: to_string(value)} end)
+    %{message | options: options}
+  end
+
   defp prepare_message(%ValidationMessage{} = message) do
-    convert_field_name(message)
+    message
+    |> convert_field_name()
+    |> convert_options()
   end
 
   defp prepare_message(message) when is_binary(message) do

--- a/test/payload_test.exs
+++ b/test/payload_test.exs
@@ -89,7 +89,7 @@ defmodule Kronky.PayloadTest do
       changeset = {%{}, %{title: :string, title_lang: :string}}
         |> Ecto.Changeset.cast(%{}, [:title, :title_lang])
         |> add_error(:title, "error 1")
-        |> add_error(:title, "error 2")
+        |> add_error(:title, "error 2", opt1: "option 1")
         |> add_error(:title_lang, "error 3")
       resolution = resolution(changeset)
 
@@ -97,7 +97,7 @@ defmodule Kronky.PayloadTest do
 
       messages = [
         %ValidationMessage{code: :unknown, message: "error 1", template: "error 1", field: :title, key: :title},
-        %ValidationMessage{code: :unknown, message: "error 2", template: "error 2", field: :title, key: :title},
+        %ValidationMessage{code: :unknown, message: "error 2", template: "error 2", field: :title, key: :title, options: [%{key: "opt1", value: "option 1"}]},
         %ValidationMessage{code: :unknown, message: "error 3", template: "error 3", field: :titleLang, key: :titleLang},
       ]
 


### PR DESCRIPTION
This PR fixes #2 by properly encoding the validation options keyworld list into a list of maps (with "key" and "value" fields), according to the expected schema in `ValidationMessageTypes`:

https://github.com/Ethelo/kronky/blob/0f74b8c4f2f3562bd7d0d49b00ef71abc62fab00/lib/kronky/validation_message_types.ex#L94-L97