### PR TITLE
Fix warnings

### DIFF
--- a/lib/kronky/changeset_parser.ex
+++ b/lib/kronky/changeset_parser.ex
@@ -4,7 +4,7 @@ defmodule Kronky.ChangesetParser do
   Currently *does not* support nested errors
   """
 
-  import Ecto.Changeset, only: ["traverse_errors": 2]
+  import Ecto.Changeset, only: [traverse_errors: 2]
   alias Kronky.ValidationMessage
 
   @doc "Extract a nested map of raw errors from a changeset

--- a/lib/kronky/payload.ex
+++ b/lib/kronky/payload.ex
@@ -17,13 +17,13 @@ defmodule Kronky.Payload do
   2. `import_types Kronky.ValidationMessageTypes`
   3. create a payload object for each object using `payload_object(payload_name, object_name)`
   4. create a mutation that returns the payload object. Add the payload middleware after the resolver.
-    ```
-    field :create_user, type: :user_payload, description: "add a user" do
-      arg :user, :create_user_params
-      resolve &UserResolver.create/2
-      middleware &build_payload/2
-    end
-    ```
+  ```
+  field :create_user, type: :user_payload, description: "add a user" do
+    arg :user, :create_user_params
+    resolve &UserResolver.create/2
+    middleware &build_payload/2
+  end
+  ```
 
   ## Example Schema
 
@@ -32,61 +32,61 @@ defmodule Kronky.Payload do
   ```elixir
 
   defmodule MyApp.Schema.User do
-    @moduledoc false
+  @moduledoc false
 
-    use Absinthe.Schema.Notation
-    import Kronky.Payload
-    import_types Kronky.ValidationMessageTypes
+  use Absinthe.Schema.Notation
+  import Kronky.Payload
+  import_types Kronky.ValidationMessageTypes
 
-    alias MyApp.Resolvers.User, as: UserResolver
+  alias MyApp.Resolvers.User, as: UserResolver
 
-    object :user, description: "Someone on our planet" do
-      field :id, non_null(:id), description: "unique identifier"
-      field :first_name, non_null(:string), description: "User's first name"
-      field :last_name, :string, description: "Optional Last Name"
-      field :age, :integer, description: "Age in Earth years"
-      field :inserted_at, :time, description: "Created at"
-      field :updated_at, :time, description: "Last updated at"
+  object :user, description: "Someone on our planet" do
+    field :id, non_null(:id), description: "unique identifier"
+    field :first_name, non_null(:string), description: "User's first name"
+    field :last_name, :string, description: "Optional Last Name"
+    field :age, :integer, description: "Age in Earth years"
+    field :inserted_at, :time, description: "Created at"
+    field :updated_at, :time, description: "Last updated at"
+  end
+
+  input_object :create_user_params, description: "create a user" do
+    field :first_name, non_null(:string), description: "Required first name"
+    field :last_name, :string, description: "Optional last name"
+    field :age, :integer, description: "Age in Earth years"
+  end
+
+  payload_object(:user_payload, :user)
+
+  object :user_mutations do
+
+    field :create_user, type: :user_payload, description: "Create a new user" do
+      arg :user, :create_user_params
+      resolve &UserResolver.create/2
+      middleware &build_payload/2
     end
+  end
+  ```
 
-    input_object :create_user_params, description: "create a user" do
-      field :first_name, non_null(:string), description: "Required first name"
-      field :last_name, :string, description: "Optional last name"
-      field :age, :integer, description: "Age in Earth years"
-    end
+  In your main schema file
 
-    payload_object(:user_payload, :user)
+  ```
+  import_types MyApp.Schema.User
 
-    object :user_mutations do
+  mutation do
+   ...
+   import_fields :user_mutations
+  end
+  ```
 
-      field :create_user, type: :user_payload, description: "Create a new user" do
-        arg :user, :create_user_params
-        resolve &UserResolver.create/2
-        middleware &build_payload/2
-      end
-    end
-    ```
+  ## Alternate Use
 
-    In your main schema file
+  If you'd prefer not to use the middleware style, you can generate Kronky payloads
+  in your resolver instead. See `success_payload/1` and `error_payload/1` for examples.
 
-    ```
-    import_types MyApp.Schema.User
-
-    mutation do
-     ...
-     import_fields :user_mutations
-    end
-    ```
-
-    ## Alternate Use
-
-    If you'd prefer not to use the middleware style, you can generate Kronky payloads
-    in your resolver instead. See `success_payload/1` and `error_payload/1` for examples.
-
-    """
+  """
 
   @enforce_keys [:successful]
-  defstruct [successful: nil, messages: [], result: nil]
+  defstruct successful: nil, messages: [], result: nil
   alias __MODULE__
   alias Kronky.ValidationMessage
   import Kronky.ChangesetParser
@@ -117,15 +117,22 @@ defmodule Kronky.Payload do
   """
   defmacro payload_object(payload_name, result_object_name) do
     quote location: :keep do
-
       object unquote(payload_name) do
-        field :successful, non_null(:boolean), description: "Indicates if the mutation completed successfully or not. "
-        field :messages, list_of(:validation_message), description: "A list of failed validations. May be blank or null if mutation succeeded."
-        field :result, unquote(result_object_name), description: "The object created/updated/deleted by the mutation. May be null if mutation failed."
+        field(:successful, non_null(:boolean),
+          description: "Indicates if the mutation completed successfully or not. "
+        )
+
+        field(:messages, list_of(:validation_message),
+          description: "A list of failed validations. May be blank or null if mutation succeeded."
+        )
+
+        field(:result, unquote(result_object_name),
+          description:
+            "The object created/updated/deleted by the mutation. May be null if mutation failed."
+        )
       end
     end
   end
-
 
   @doc """
   Convert a resolution value to a mutation payload
@@ -310,6 +317,7 @@ defmodule Kronky.Payload do
   ```
   """
   def error_payload(%ValidationMessage{} = message), do: error_payload([message])
+
   def error_payload(messages) when is_list(messages) do
     messages = messages |> Enum.map(&prepare_message/1)
     %Payload{successful: false, messages: messages}
@@ -317,15 +325,18 @@ defmodule Kronky.Payload do
 
   @doc "convert validation message field to camelCase format used by graphQL"
   def convert_field_name(%ValidationMessage{} = message) do
-    field = cond do
-      message.field == nil -> camelized_name(message.key)
-      message.key == nil -> camelized_name(message.field)
-      true -> camelized_name(message.field)
-    end
+    field =
+      cond do
+        message.field == nil -> camelized_name(message.key)
+        message.key == nil -> camelized_name(message.field)
+        true -> camelized_name(message.field)
+      end
+
     %{message | field: field, key: field}
   end
 
   defp camelized_name(nil), do: nil
+
   defp camelized_name(field) do
     field |> to_string() |> Absinthe.Utils.camelize(lower: true)
   end
@@ -375,8 +386,11 @@ defmodule Kronky.Payload do
 
   defp generic_validation_message(message) do
     %ValidationMessage{
-      code: :unknown, field: nil, template: message, message: message, options: []
+      code: :unknown,
+      field: nil,
+      template: message,
+      message: message,
+      options: []
     }
   end
-
 end

--- a/lib/kronky/validation_message_types.ex
+++ b/lib/kronky/validation_message_types.ex
@@ -40,7 +40,7 @@ defmodule Kronky.ValidationMessageTypes do
   """
   use Absinthe.Schema.Notation
 
-  #simplify access to reusable descriptions
+  # simplify access to reusable descriptions
   @descs %{
     validation_message: """
       Validation messages are returned when mutation input does not meet the requirements.
@@ -57,7 +57,7 @@ defmodule Kronky.ValidationMessageTypes do
       set to optional in our API. This allows 'required field' messages
       to be returned in the same manner as other validations. The only exceptions
       are id fields, which may be required to perform updates or deletes.
-    """  ,
+    """,
     field: "The input field that the error applies to. The field can be used to
     identify which field the error message should be displayed next to in the
     presentation layer.
@@ -75,7 +75,8 @@ defmodule Kronky.ValidationMessageTypes do
 
     This message may change without notice, so we do not recommend you match against the text.
     Instead, use the *code* field for matching.",
-    template: "A template used to generate the error message, with placeholders for option substiution.
+    template:
+      "A template used to generate the error message, with placeholders for option substiution.
 
     Example: `Username must be at least {count} characters`
 
@@ -88,20 +89,19 @@ defmodule Kronky.ValidationMessageTypes do
     TODO: Add list",
     option_key: "The name of a variable to be subsituted in a validation message template",
     option_value: "The value of a variable to be substituted in a validation message template",
-    option_list: "A list of substitutions to be applied to a validation message template",
-    }
+    option_list: "A list of substitutions to be applied to a validation message template"
+  }
 
   object :validation_option do
-    field :key, non_null(:string), description: @descs.option_key
-    field :value, non_null(:string), description: @descs.option_value
+    field(:key, non_null(:string), description: @descs.option_key)
+    field(:value, non_null(:string), description: @descs.option_value)
   end
 
   object :validation_message, description: @descs.validation_message do
-    field :field, :string, description: @descs.field
-    field :message, :string, description: @descs.message
-    field :code, non_null(:string), description: @descs.code
-    field :template, :string, description: @descs.template
-    field :options, list_of(:validation_option), description: @descs.option_list
+    field(:field, :string, description: @descs.field)
+    field(:message, :string, description: @descs.message)
+    field(:code, non_null(:string), description: @descs.code)
+    field(:template, :string, description: @descs.template)
+    field(:options, list_of(:validation_option), description: @descs.option_list)
   end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Kronky.Mixfile do
       version: @version,
       elixir: "~> 1.4",
       test_coverage: [tool: ExCoveralls],
-      preferred_cli_env: ["coveralls": :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
+      preferred_cli_env: [coveralls: :test, "coveralls.detail": :test, "coveralls.post": :test, "coveralls.html": :test],
       build_embedded: Mix.env == :prod,
       start_permanent: Mix.env == :prod,
       deps: deps(),


### PR DESCRIPTION
Fixes several warnings like this one:
```
warning: found quoted keyword "coveralls" but the quotes are not required. Note that keywords are always atoms, even when quoted, and quotes should only be used to introduce keywords with foreign characters in them
```

Fixes indentation errors, and some documentation warnings